### PR TITLE
feat: enhance email handling and self-healing functionality

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -56,6 +56,24 @@ export default defineConfig({
         access: 'secret',
         optional: true,
       }),
+      RESEND_TO_EMAIL: envField.string({
+        context: 'server',
+        access: 'public',
+        optional: true,
+        default: 'jorgelsaud@gmail.com'
+      }),
+      RESEND_FROM_EMAIL: envField.string({
+        context: 'server',
+        access: 'public',
+        optional: true,
+        default: 'notebook@web.giorgiosaud.io'
+      }),
+      RESEND_FROM_NAME: envField.string({
+        context: 'server',
+        access: 'public',
+        optional: true,
+        default: 'Notebook'
+      })
     },
   },
 

--- a/src/actions/sendEmail.ts
+++ b/src/actions/sendEmail.ts
@@ -1,5 +1,5 @@
 import { ActionError, defineAction } from 'astro:actions'
-import { RESEND_API_KEY } from 'astro:env/server'
+import { RESEND_API_KEY, RESEND_FROM_EMAIL, RESEND_FROM_NAME, RESEND_TO_EMAIL } from 'astro:env/server'
 
 import { Resend } from 'resend'
 
@@ -17,8 +17,8 @@ export const sendEmail = defineAction({
   }),
   handler: async (input) => {
     const { data, error } = await resend.emails.send({
-      from: 'Website <notebook@web.giorgiosaud.io>',
-      to: ['jorgelsaud@gmail.com'],
+      from: `${RESEND_FROM_NAME} <${RESEND_FROM_EMAIL}>`,
+      to: [RESEND_TO_EMAIL],
       subject: `Email from ${input.name} in Website Form`,
       html: `
             <h1>New message from ${input.name}</h1>

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -1,271 +1,34 @@
 ---
-import OnePassword from '@icons/1Password.astro'
-import Algolia from '@icons/Algolia.svg'
-import AMP from '@icons/AMP.svg'
-import Android from '@icons/Android.svg'
-import Angular from '@icons/Angular.svg'
-import API from '@icons/API.astro'
-import Apidog from '@icons/Apidog.svg'
-import Apple from '@icons/Apple.astro'
-import AstroIcon from '@icons/AstroIcon.astro'
-import Atlassian from '@icons/Atlassian.svg'
-import Atom from '@icons/Atom.svg'
-import Auth0 from '@icons/Auth0.svg'
-import Authy from '@icons/Authy.svg'
-import AWS from '@icons/AWS.astro'
-import Bash from '@icons/Bash.astro'
-import Bootstrap from '@icons/Bootstrap.svg'
-import Bun from '@icons/Bun.svg'
-import Calendly from '@icons/Calendly.svg'
-import Canva from '@icons/Canva.svg'
-import ChadUI from '@icons/ChadUI.astro'
-import ChakraUI from '@icons/ChakraUI.svg'
-import Chartjs from '@icons/Chartjs.svg'
-import Cloudflare from '@icons/Cloudflare.svg'
-import CloudflareWorkers from '@icons/CloudflareWorkers.svg'
-import Cloudinary from '@icons/Cloudinary.svg'
-import Codesandbox from '@icons/Codesandbox.svg'
-import Community from '@icons/Community.astro'
-import Coursera from '@icons/Coursera.svg'
-import CSS from '@icons/CSS.svg'
-import CSSOld from '@icons/CSSOld.svg'
-import Cypress from '@icons/Cypress.svg'
-import DaisyUI from '@icons/DaisyUI.svg'
-import Deno from '@icons/Deno.astro'
-import Directus from '@icons/Directus.svg'
-import Dotenvx from '@icons/Dotenvx.svg'
-import Drizzle from '@icons/Drizzle.astro'
-import Expo from '@icons/Expo.svg'
-import Figma from '@icons/Figma.svg'
-import Firebase from '@icons/Firebase.svg'
-import Flowbite from '@icons/Flowbite.svg'
-import Flutter from '@icons/Flutter.svg'
-import Frameworks from '@icons/Frameworks.astro'
-import Gimp from '@icons/Gimp.svg'
-import Git from '@icons/Git.svg'
-import GitHub from '@icons/GitHub.astro'
-import GithubCopilot from '@icons/GithubCopilot.astro'
-import Globe from '@icons/Globe.astro'
-import Graphql from '@icons/Graphql.astro'
-import Heroku from '@icons/Heroku.svg'
-import Homebrew from '@icons/Homebrew.svg'
-import HTML5 from '@icons/HTML5.svg'
-import Illustrator from '@icons/Illustrator.svg'
-import Integration from '@icons/Integration/index.astro'
-import Intellijidea from '@icons/Intellijidea.svg'
-import Java from '@icons/Java.svg'
-import Javascript from '@icons/Javascript.svg'
-import Jest from '@icons/Jest.svg'
-import JSON from '@icons/JSON.svg'
-import JsonSchema from '@icons/JsonSchema.svg'
-import JWT from '@icons/JWT.svg'
-import jQuery from '@icons/jQuery.astro'
-import Keycloak from '@icons/Keycloak.svg'
-import Kotlin from '@icons/Kotlin.svg'
-import Laravel from '@icons/Laravel.svg'
-import Lit from '@icons/Lit.svg'
-import Mariadb from '@icons/Mariadb.svg'
-import Markdown from '@icons/Markdown.astro'
-import MercadoPago from '@icons/MercadoPago.svg'
-import Modyo from '@icons/Modyo.astro'
-import Mongodb from '@icons/Mongodb.svg'
-import Mysql from '@icons/Mysql.svg'
-import Neovim from '@icons/Neovim.svg'
-import Ngrok from '@icons/Ngrok.astro'
-import Nodejs from '@icons/Nodejs.svg'
-import Note from '@icons/Note.astro'
-import Notion from '@icons/Notion.svg'
-import Npm from '@icons/Npm.svg'
-import Nx from '@icons/Nx.astro'
-import Patterns from '@icons/Patterns.astro'
-import Photoshop from '@icons/Photoshop.svg'
-import Php from '@icons/Php.astro'
-import Pinia from '@icons/Pinia.svg'
-import Platzi from '@icons/Platzi.svg'
-import Playwright from '@icons/Playwright.svg'
-import Pnpm from '@icons/Pnpm.astro'
-import Postman from '@icons/Postman.svg'
-import Preact from '@icons/Preact.svg'
-import Prettier from '@icons/Prettier.astro'
-import React from '@icons/React.astro'
-import ReactQuery from '@icons/ReactQuery.svg'
-import ReactRouter from '@icons/ReactRouter.svg'
-import Redis from '@icons/Redis.svg'
-import Redux from '@icons/Redux.svg'
-import SASS from '@icons/SASS.svg'
-import Sanity from '@icons/Sanity.svg'
-import Shopify from '@icons/Shopify.astro'
-import Sketch from '@icons/Sketch.astro'
-import Slack from '@icons/Slack.svg'
-import Spring from '@icons/Spring.svg'
-import Sqlite from '@icons/Sqlite.svg'
-import Storybook from '@icons/Storybook.svg'
-import Styledcomponents from '@icons/Styledcomponents.svg'
-import Supabase from '@icons/Supabase.svg'
-import SVG from '@icons/SVG.svg'
-import Svelte from '@icons/Svelte.svg'
-import Swagger from '@icons/Swagger.svg'
-import Swift from '@icons/Swift.svg'
-import TailwindCss from '@icons/TailwindCss.astro'
-import Tanstack from '@icons/Tanstack.svg'
-import Tensorflow from '@icons/Tensorflow.svg'
-import ThreeJS from '@icons/ThreeJS.astro'
-import Turso from '@icons/Turso.astro'
-import Typeorm from '@icons/Typeorm.svg'
-import Typescript from '@icons/Typescript.svg'
-import Udemy from '@icons/Udemy.astro'
-import USA from '@icons/USA.svg'
-import Venezuela from '@icons/Venezuela.svg'
-import Vercel from '@icons/Vercel.astro'
-import VIM from '@icons/VIM.svg'
-import Vitest from '@icons/Vitest.svg'
-import VSCode from '@icons/VSCode.svg'
-import Vue from '@icons/Vue.svg'
-import Webcomponents from '@icons/Webcomponents.svg'
-import Webdev from '@icons/Webdev.svg'
-import Webstorm from '@icons/Webstorm.svg'
-import Wordpress from '@icons/Wordpress.svg'
-import Zod from '@icons/Zod.svg'
+const modules = import.meta.glob('../icons/**/*.{astro,svg}');
 
-interface Icon {
-  [key: string]: any
-}
-const Icons: Icon = {
-  API,
-  jQuery,
-  Community,
-  Php,
-  Pnpm,
-  Markdown,
-  ThreeJS,
-  Udemy,
-  Frameworks,
-  Prettier,
-  ChadUI,
-  Ngrok,
-  Nx,
-  GithubCopilot,
-  Angular,
-  GitHub,
-  Globe,
-  Integration,
-  Note,
-  Patterns,
-  React,
-  Vue,
-  Svelte,
-  Preact,
-  AstroIcon,
-  Webcomponents,
-  TailwindCss,
-  Laravel,
-  Spring,
-  Vercel,
-  Cloudflare,
-  Cloudinary,
-  Keycloak,
-  Directus,
-  Sanity,
-  Shopify,
-  Wordpress,
-  Mysql,
-  Modyo,
-  Mariadb,
-  Mongodb,
-  Redis,
-  Sqlite,
-  Supabase,
-  Typeorm,
-  Drizzle,
-  Turso,
-  Canva,
-  Photoshop,
-  Figma,
-  Gimp,
-  Illustrator,
-  Sketch,
-  SVG,
-  Zod,
-  OnePassword,
-  Algolia,
-  AMP,
-  Android,
-  Apidog,
-  Atlassian,
-  Atom,
-  Auth0,
-  Authy,
-  Bootstrap,
-  Bun,
-  Calendly,
-  ChakraUI,
-  Chartjs,
-  CloudflareWorkers,
-  Codesandbox,
-  Coursera,
-  CSS,
-  CSSOld,
-  Cypress,
-  DaisyUI,
-  Dotenvx,
-  Expo,
-  Firebase,
-  Flowbite,
-  Flutter,
-  Git,
-  Graphql,
-  Heroku,
-  Homebrew,
-  HTML5,
-  Intellijidea,
-  Java,
-  Javascript,
-  Jest,
-  JSON,
-  JsonSchema,
-  JWT,
-  Kotlin,
-  Lit,
-  MercadoPago,
-  Neovim,
-  Nodejs,
-  Notion,
-  Npm,
-  Pinia,
-  Platzi,
-  Bash,
-  Deno,
-  Playwright,
-  Postman,
-  ReactQuery,
-  ReactRouter,
-  Redux,
-  SASS,
-  Slack,
-  Storybook,
-  Styledcomponents,
-  Swagger,
-  Swift,
-  Tanstack,
-  Tensorflow,
-  Typescript,
-  VIM,
-  Vitest,
-  VSCode,
-  Webdev,
-  AWS,
-  Apple,
-  Webstorm,
-  Venezuela,
-  USA,
-}
 export interface Props {
-  name: keyof typeof Icons
+  name: string;
 }
-const { name } = Astro.props
-const IconInstance = Icons[name]
+const { name } = Astro.props;
+
+let IconComponent = null;
+
+// Find the correct module path
+const path = Object.keys(modules).find(p => {
+    const pathParts = p.split('/');
+    const fileNameWithExt = pathParts.pop() || '';
+    const fileName = fileNameWithExt.split('.')[0];
+
+    if (fileName === 'index') {
+        const parentDir = pathParts.pop();
+        return parentDir === name;
+    }
+    return fileName === name;
+});
+
+if (path) {
+    const module = await modules[path]();
+    IconComponent = module.default;
+}
 ---
-{ IconInstance?
-    (<IconInstance />):
-    <p>Icon {name} not found</p>
-}
+
+{IconComponent ? (
+  <IconComponent />
+) : (
+  <p>Icon {name} not found</p>
+)}

--- a/src/content/badges/config.ts
+++ b/src/content/badges/config.ts
@@ -1,33 +1,28 @@
-import { defineCollection, z } from 'astro:content'
-import { glob } from 'astro/loaders'
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const badgeSchema = z.object({
+  slug: z.string(),
+  title: z.string(),
+  imgSrc: z.string(),
+  description: z.string(),
+  cardColor: z.string(),
+  category: z.string(),
+  date: z.date(),
+  poweredBy: z.string(),
+});
 
 export const badges = defineCollection({
-  loader: glob({ pattern: '**\/[^_]*.md', base: './src/content/badges/en' }),
-  schema: z.object({
-    slug: z.string(),
-    title: z.string(),
-    imgSrc: z.string(),
-    description: z.string(),
-    cardColor: z.string(),
-    category: z.string(),
-    date: z.date(),
-    poweredBy: z.string(),
-  }),
-})
+  loader: glob({ pattern: '**/[^_]*.md', base: './src/content/badges/en' }),
+  schema: badgeSchema,
+});
+
 export const insignias = defineCollection({
-  loader: glob({ pattern: '**\/[^_]*.md', base: './src/content/badges/es' }),
-  schema: z.object({
-    slug: z.string(),
-    title: z.string(),
-    imgSrc: z.string(),
-    description: z.string(),
-    cardColor: z.string(),
-    category: z.string(),
-    date: z.date(),
-    poweredBy: z.string(),
-  }),
-})
+  loader: glob({ pattern: '**/[^_]*.md', base: './src/content/badges/es' }),
+  schema: badgeSchema,
+});
+
 export default {
   badges,
   insignias,
-}
+};

--- a/src/content/collections/config.ts
+++ b/src/content/collections/config.ts
@@ -1,29 +1,29 @@
-import { defineCollection, z } from 'astro:content'
-import { glob } from 'astro/loaders'
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const collectionSchema = z.object({
+  title: z.string(),
+  icon: z.string(),
+  description: z.string(),
+});
 
 export const collections = defineCollection({
   loader: glob({
-    pattern: '**\/[^_]*.md',
+    pattern: '**/[^_]*.md',
     base: './src/content/collections/en',
   }),
-  schema: z.object({
-    title: z.string(),
-    icon: z.string(),
-    description: z.string(),
-  }),
-})
+  schema: collectionSchema,
+});
+
 export const colecciones = defineCollection({
   loader: glob({
-    pattern: '**\/[^_]*.md',
+    pattern: '**/[^_]*.md',
     base: './src/content/collections/es',
   }),
-  schema: z.object({
-    title: z.string(),
-    icon: z.string(),
-    description: z.string(),
-  }),
-})
+  schema: collectionSchema,
+});
+
 export default {
   collections,
   colecciones,
-}
+};

--- a/src/content/pages/config.ts
+++ b/src/content/pages/config.ts
@@ -1,24 +1,23 @@
-import { defineCollection, z } from 'astro:content'
-import { glob } from 'astro/loaders'
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const pageSchema = z.object({
+  title: z.string(),
+  description: z.string(),
+  pathToTranslate: z.string(),
+});
 
 export const pages = defineCollection({
   loader: glob({ base: 'src/content/pages/en', pattern: '*.(md|mdx)' }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    pathToTranslate: z.string(),
-  }),
-})
+  schema: pageSchema,
+});
 
 export const paginas = defineCollection({
   loader: glob({ base: 'src/content/pages/es', pattern: '*.(md|mdx)' }),
-  schema: z.object({
-    title: z.string(),
-    description: z.string(),
-    pathToTranslate: z.string(),
-  }),
-})
+  schema: pageSchema,
+});
+
 export default {
   pages,
   paginas,
-}
+};

--- a/src/content/portfolio/config.ts
+++ b/src/content/portfolio/config.ts
@@ -1,51 +1,36 @@
-import { defineCollection, z } from 'astro:content'
-import { glob } from 'astro/loaders'
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const portfolioSchema = z.object({
+  draft: z.boolean(),
+  client: z.string(),
+  country: z.string(),
+  category: z.string(),
+  selfHealing: z.string().length(6).optional(),
+  workingOn: z.string(),
+  project: z.string(),
+  resume: z.string(),
+  classes: z.string().optional(),
+  classesClient: z.string().optional(),
+  image: z.object({
+    src: z.string(),
+    alt: z.string(),
+  }),
+  publishDate: z.string().transform((str) => new Date(str)),
+  technologies: z.array(z.string()),
+});
 
 export const portfolio = defineCollection({
   loader: glob({ pattern: '*.(md|mdx)', base: './src/content/portfolio/en' }),
+  schema: portfolioSchema,
+});
 
-  schema: z.object({
-    draft: z.boolean(),
-    client: z.string(),
-    country: z.string(),
-    category: z.string(),
-    selfHealing: z.string().length(6).optional(),
-    workingOn: z.string(),
-    project: z.string(),
-    resume: z.string(),
-    classes: z.string().optional(),
-    classesClient: z.string().optional(),
-    image: z.object({
-      src: z.string(),
-      alt: z.string(),
-    }),
-    publishDate: z.string().transform((str) => new Date(str)),
-    technologies: z.array(z.string()),
-  }),
-})
 export const portafolio = defineCollection({
   loader: glob({ pattern: '*.(md|mdx)', base: './src/content/portfolio/es' }),
+  schema: portfolioSchema,
+});
 
-  schema: z.object({
-    draft: z.boolean(),
-    client: z.string(),
-    country: z.string(),
-    category: z.string(),
-    selfHealing: z.string().length(6).optional(),
-    workingOn: z.string(),
-    project: z.string(),
-    resume: z.string(),
-    classes: z.string().optional(),
-    classesClient: z.string().optional(),
-    image: z.object({
-      src: z.string(),
-      alt: z.string(),
-    }),
-    publishDate: z.string().transform((str) => new Date(str)),
-    technologies: z.array(z.string()),
-  }),
-})
 export default {
   portafolio,
   portfolio,
-}
+};

--- a/src/content/team/config.ts
+++ b/src/content/team/config.ts
@@ -1,40 +1,31 @@
-import { defineCollection, z } from 'astro:content'
-import { glob } from 'astro/loaders'
+import { defineCollection, z } from 'astro:content';
+import { glob } from 'astro/loaders';
+
+const teamSchema = z.object({
+  draft: z.boolean(),
+  alias: z.string(),
+  name: z.string(),
+  title: z.string(),
+  resume: z.string(),
+  pathToTranslate: z.string(),
+  avatar: z.object({
+    src: z.string(),
+    alt: z.string(),
+  }),
+  publishDate: z.string().transform((str) => new Date(str)),
+});
 
 export const equipo = defineCollection({
   loader: glob({ base: 'src/content/team/es', pattern: '*.(md|mdx)' }),
-  schema: z.object({
-    draft: z.boolean(),
-    alias: z.string(),
-    name: z.string(),
-    title: z.string(),
-    resume: z.string(),
-    pathToTranslate: z.string(),
-    avatar: z.object({
-      src: z.string(),
-      alt: z.string(),
-    }),
-    publishDate: z.string().transform((str) => new Date(str)),
-  }),
-})
+  schema: teamSchema,
+});
 
 export const team = defineCollection({
   loader: glob({ base: 'src/content/team/en', pattern: '*.(md|mdx)' }),
-  schema: z.object({
-    draft: z.boolean(),
-    alias: z.string(),
-    name: z.string(),
-    title: z.string(),
-    resume: z.string(),
-    pathToTranslate: z.string(),
-    avatar: z.object({
-      src: z.string(),
-      alt: z.string(),
-    }),
-    publishDate: z.string().transform((str) => new Date(str)),
-  }),
-})
+  schema: teamSchema,
+});
+
 export default {
   team,
   equipo,
-}
+};

--- a/src/global/components/Head/PWA.astro
+++ b/src/global/components/Head/PWA.astro
@@ -19,7 +19,7 @@ const { version = 'v1' } = Astro.props
   />
   <script>
 
-    if ('serviceWorker' in navigator && location.hostname === 'giorgiosaud.io') {
+    if ('serviceWorker' in navigator && import.meta.env.PROD) {
       navigator.serviceWorker.register('service-worker.js');
     }
   </script>

--- a/src/global/styles/md.css
+++ b/src/global/styles/md.css
@@ -1,3 +1,4 @@
+@layer global{
 * {
   --_color: var(--color, light-dark(var(--color-main), var(--color-light)));
   color: var(--_color);
@@ -49,4 +50,6 @@ blockquote {
     position: absolute;
     left: 0;
   }
+}
+
 }

--- a/src/helpers/selfHeal.ts
+++ b/src/helpers/selfHeal.ts
@@ -1,0 +1,20 @@
+import { getCollection } from 'astro:content';
+import type { AstroGlobal } from 'astro';
+
+export async function selfHeal(Astro: AstroGlobal, collectionName: 'notes' | 'notas') {
+  const notes = await getCollection(collectionName);
+  const selfhealPath = Astro.params.selfheal;
+  const selfHealRegex = /(?<=^|-)[^aeiouAEIOU-]{6}(?=-|$)/g;
+  const selfHealing = selfhealPath?.match(selfHealRegex) || [];
+
+  if (selfHealing.length) {
+    for (const sh of selfHealing) {
+      const note = notes.find((note) => note.data.selfHealing === sh);
+      if (note) {
+        const basePath = collectionName === 'notes' ? '/notebook' : '/es/cuaderno';
+        return Astro.redirect(`${basePath}/${note.id}`, 301);
+      }
+    }
+  }
+  return null;
+}

--- a/src/pages/es/cuaderno/[selfheal].astro
+++ b/src/pages/es/cuaderno/[selfheal].astro
@@ -1,25 +1,12 @@
 ---
-import { getCollection } from 'astro:content'
-import NotFound from '@pages/404.astro'
+import { selfHeal } from '@helpers/selfHeal';
+import NotFound from '@pages/404.astro';
 
-export const prerender = false
+export const prerender = false;
 
-const notes = await getCollection('notas')
-const selfhealPath = Astro.params.selfheal
-const selfHealRegex = /(?<=^|-)[^aeiouAEIOU-]{6}(?=-|$)/g
-const selfHealing = selfhealPath?.match(selfHealRegex) || []
-
-if (selfHealing.length) {
-  for (const sh of selfHealing) {
-    const note = notes.find((note) => note.data.selfHealing === sh)
-    if (note) {
-      Astro.response.status = 301
-      Astro.response.headers.set('location', `/es/cuaderno/${note.id}`)
-      break
-    }
-  }
-} else {
-  Astro.response.status = 404
+const redirect = await selfHeal(Astro, 'notas');
+if (redirect) {
+  return redirect;
 }
 ---
 

--- a/src/pages/notebook/[selfheal].astro
+++ b/src/pages/notebook/[selfheal].astro
@@ -1,24 +1,12 @@
 ---
-import { getCollection } from 'astro:content'
-import NotFound from '@pages/404.astro'
+import { selfHeal } from '@helpers/selfHeal';
+import NotFound from '@pages/404.astro';
 
-export const prerender = false
+export const prerender = false;
 
-const notes = await getCollection('notes')
-const selfhealPath = Astro.params.selfheal
-const selfHealRegex = /(?<=^|-)[^-]{6}(?=-|$)/g
-const selfHealing = selfhealPath?.match(selfHealRegex) || []
-if (selfHealing.length) {
-  for (const sh of selfHealing) {
-    const note = notes.find((note) => note.data.selfHealing === sh)
-    if (note) {
-      Astro.response.status = 301
-      Astro.response.headers.set('location', `/notebook/${note.id}`)
-      break
-    }
-  }
-} else {
-  Astro.response.status = 404
+const redirect = await selfHeal(Astro, 'notes');
+if (redirect) {
+  return redirect;
 }
 ---
 


### PR DESCRIPTION
This pull request introduces several updates to improve email handling, streamline content schema definitions, optimize icon handling, and enhance self-healing functionality for routes. Below is a summary of the most important changes grouped by theme.

### Email Configuration and Handling
* Added new environment variables (`RESEND_FROM_EMAIL`, `RESEND_FROM_NAME`, `RESEND_TO_EMAIL`) to `astro.config.mjs` for flexible email configuration with default values.
* Updated `src/actions/sendEmail.ts` to use the new environment variables for dynamic email sender and recipient details. [[1]](diffhunk://#diff-85a54f80d3dbf495dc59d56997ba3e6036812461c1aae9fd66d3259620519defL2-R2) [[2]](diffhunk://#diff-85a54f80d3dbf495dc59d56997ba3e6036812461c1aae9fd66d3259620519defL20-R21)

### Content Schema Refactoring
* Extracted shared schemas (`badgeSchema`, `collectionSchema`, `pageSchema`, `portfolioSchema`, `teamSchema`) in various content configuration files (`src/content/badges/config.ts`, `src/content/collections/config.ts`, `src/content/pages/config.ts`, `src/content/portfolio/config.ts`, `src/content/team/config.ts`) to reduce redundancy and improve maintainability. [[1]](diffhunk://#diff-e1964ca0ba9685ac9b711905d4fe308b93a513c3fa8c8f6f157074cee7d1a546L1-R4) [[2]](diffhunk://#diff-c243927c67048bc7fd99f51f4ddde4dd93e02ae598e32be5792e4bf893e4807eL1-R29) [[3]](diffhunk://#diff-219e433f90309bdde6d7da10293f67ac06b2116afb22604445edcad76c93d82eL1-R23) [[4]](diffhunk://#diff-161f557ab00d2f8ad17a224f02d8227fc9e3d0ee564a9a31697b19cf070ae4cdL1-R4) [[5]](diffhunk://#diff-0130e6b14d39a42dce643e1b0dc042c44109388bba75089a5fff27336e3d9515L1-R4)

### Icon Handling Optimization
* Replaced individual icon imports in `src/components/Icon.astro` with a dynamic `import.meta.glob` implementation to load icons on demand, significantly reducing the file's size and improving scalability.

### Self-Healing Route Enhancements
* Introduced a reusable `selfHeal` helper function in `src/helpers/selfHeal.ts` to handle self-healing redirects for both English and Spanish notebooks.
* Refactored `src/pages/es/cuaderno/[selfheal].astro` and `src/pages/notebook/[selfheal].astro` to use the new `selfHeal` helper, simplifying the logic and improving code reuse. ([src/pages/es/cuaderno/[selfheal].astroL2-R9](diffhunk://#diff-569ec42055e7829850b4f4a437fe4ab9d66028d847d1a40427708c0e91a7cdb7L2-R9), [src/pages/notebook/[selfheal].astroL2-R9](diffhunk://#diff-b7b1f00afaa2a3a799ae09f1bc4006aac8bea134dab71d0d0ba921c7e11e93acL2-R9))

### Miscellaneous Improvements
* Updated service worker registration in `src/global/components/Head/PWA.astro` to check for `import.meta.env.PROD` instead of a hardcoded hostname.
* Added a global CSS layer in `src/global/styles/md.css` for better style encapsulation. [[1]](diffhunk://#diff-7e9625258075eedcfd5239c3773d71c860f43037a61eaa5c5f5e856604726413R1) [[2]](diffhunk://#diff-7e9625258075eedcfd5239c3773d71c860f43037a61eaa5c5f5e856604726413R54-R55)…configurations and helper methods