### PR TITLE
fix: update package manager version in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "new-giorgiosaud-io",
   "type": "module",
   "version": "0.0.1",
+  "packageManager": "pnpm@10.17.1",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",


### PR DESCRIPTION
This pull request introduces a minor update to the `package.json` file, specifying the use of `pnpm@10.17.1` as the package manager for the project.