### PR TITLE
feat: add AI summary generation button and enhance summary functional…

### DIFF
--- a/src/pages/es/cuaderno/[note].astro
+++ b/src/pages/es/cuaderno/[note].astro
@@ -10,11 +10,11 @@ export async function getStaticPaths() {
   const pagesTranslated = await getCollection('notes')
   return pages.map(page => {
     const pathToTranslateNote =
-      pagesTranslated.find(
-        translatedPage =>
-          translatedPage.data.selfHealing &&
-          translatedPage.data.selfHealing === page.data.selfHealing,
-      )?.id || ''
+    pagesTranslated.find(
+    translatedPage =>
+    translatedPage.data.selfHealing &&
+    translatedPage.data.selfHealing === page.data.selfHealing,
+    )?.id || ''
     return {
       params: {
         note: page.id,
@@ -30,27 +30,29 @@ const { page, pathToTranslateNote } = Astro.props
 
 const { Content } = await render(page)
 const { draft, title, publishDate, cover, coverAlt, selfHealing, description } =
-  page.data
+page.data
 ---
 <NoteTemplate
-  description={description}
-  draft={draft}
-  title={title}
-  image={cover}
-  publishedAt={publishDate}
-  pathToTranslateNote={pathToTranslateNote}
+description={description}
+draft={draft}
+title={title}
+image={cover}
+publishedAt={publishDate}
+pathToTranslateNote={pathToTranslateNote}
 >
-  <figure>
-    {cover && coverAlt && <Picture src={cover} alt={coverAlt} width={500}/>}
-    <figcaption>{coverAlt}</figcaption>
-  </figure>
-<div id="summary"></div>
-<div id="content">
-<h1>{title}</h1>
-<Content/>
+<figure>
+  {cover && coverAlt && <Picture src={cover} alt={coverAlt} width={500}/>}
+  <figcaption>{coverAlt}</figcaption>
+</figure>
+<div id="summary">
+  <button id="generate-summary" class="button button-primary">Generar Resumen</button>
 </div>
-  <section class="share">
-<p>Share this note:</p>
+<div id="content">
+  <h1>{title}</h1>
+  <Content/>
+</div>
+<section class="share">
+  <p>Share this note:</p>
   <p id="notification">Link copiado al portapapeles!</p>
   <button id="share" class="button button-primary" popovertarget="#share-notification">Share</button>
 </section>
@@ -60,42 +62,48 @@ const { draft, title, publishDate, cover, coverAlt, selfHealing, description } =
   if ('Summarizer' in self) {
     const summaryElement = document.getElementById('summary');
     summaryElement.classList.add('can-summarize');
-    
     async function summarizeContent(){
-    const options = {
-      sharedContext: 'This is a FrontEnd developers article',
-      type: 'teaser',
-      format: 'markdown',
-      length: 'long',
-      monitor(m) {
-        m.addEventListener('downloadprogress', (e) => {
-          console.log(`Downloaded ${e.loaded * 100}%`);
-        });
+      const options = {
+        sharedContext: 'This is a FrontEnd developers article use same language as text for the summary',
+        type: 'teaser',
+        format: 'markdown',
+        length: 'long',
+        language: 'es',
+        monitor(m) {
+          m.addEventListener('downloadprogress', (e) => {
+            console.log(`Downloaded ${e.loaded * 100}%`);
+          });
+        }
+      };
+      const availability = await Summarizer.availability();
+      if (availability === 'unavailable') {
+        // The Summarizer API isn't usable.
+        return;
       }
+      const summaryButton = document.getElementById('generate-summary');
+      summaryButton.addEventListener('click', async () => {
+        const summarizer = await Summarizer.create(options);
+        const text= document.getElementById('content').innerText;
+        summaryElement.innerText = 'Generating summary...';
+        const summary = await summarizer.summarizeStreaming(text, { language: 'es' });
+        summaryElement.innerText = '';
+        for await (const chunk of summary.values()) {
+          summaryElement.innerText += chunk;
+        }
+        console.log('Raw summary:', summaryElement.innerText);
+        summaryElement.innerHTML =
+        marked.parse(summaryElement.innerText);
+        console.log('Summary generation completed.');
+      });
+      
     };
-      const summarizer = await Summarizer.create(options);
-      console.log({summarizer})
-      const text= document.getElementById('content').innerText;
-      summaryElement.innerText = 'Generating summary...';
-      const summary = await summarizer.summarizeStreaming(text);
-      summaryElement.innerText = '';
-      for await (const chunk of summary.values()) {
-        summaryElement.innerText += chunk;
-      }
-      console.log('Raw summary:', summaryElement.innerText);
-      summaryElement.innerHTML =
-      marked.parse(summaryElement.innerText);
-      console.log('Summary generation completed.');
-      
-      
-  };
-  summarizeContent();
+    summarizeContent();
   };
 </script>
 <script define:vars={{selfHealing}}>
-        notification = document.getElementById('notification');
-
-const shareButton = document.getElementById('share');
+  notification = document.getElementById('notification');
+  
+  const shareButton = document.getElementById('share');
   const urlToShare = `${window.location.href}-${selfHealing}`;
   const copyLink = async (link)=>{
     if (navigator.clipboard) {
@@ -125,13 +133,13 @@ const shareButton = document.getElementById('share');
         console.error('Error sharing:', error);
         throw error
       }
-  }
+    }
     else{
       console.log('Share API not supported');
       throw new Error('Share API not supported');
     }
   }
-
+  
   const shareContent = async () => {
     const shareData = {
       title: document.querySelector('h1').textContent,
@@ -150,10 +158,10 @@ const shareButton = document.getElementById('share');
     }
   };
   shareButton.addEventListener('click', shareContent);
-
+  
 </script>
 <style>
-    #share{
+  #share{
     display: flex;
     justify-content: center;
     align-items: center;
@@ -182,28 +190,41 @@ const shareButton = document.getElementById('share');
       border-radius: 10px;
     }
   }
-    #content,#summary{
-      width: 100%;
+  #content,#summary{
+    width: 100%;
     max-width: 80ch;
     margin: auto;
     padding: 1rem;
-    font-size: clamp(.8rem, 2vw, 1.125rem);
     line-height: 1.6;
   }
   #summary{
+    display: none;
+  }
+  #summary :global(p) {
+    font-size: clamp(.8rem, 2vw, 1.125rem);
+  }
+  #summary :global(h1) {
+    font-size: clamp(1.2rem, 3vw, 1.8rem);
+  }
+  #summary :global(h2) {
+    font-size: clamp(1rem, 2.8vw, 1.5rem);
+  }
+  #summary :global(h3) {
+    font-size: clamp(0.875rem, 2.4vw, 1.25rem);
+  }
+  /** make this border like gemini colors moving around as gradient  */
+  #summary.can-summarize{
+    display: block;
+    margin-top: 2rem;
+    max-width: 60ch;  
+    border-left: 4px solid var(--color-accent);
+    animation: gemini-border 1s infinite ease-in cubic-bezier(0.1, -0.6, 0.2, 0);
     max-width: 60ch;
     width: 90%;
     background-color: light-dark(var(--color-summary-light), var(--color-summary-dark));
     border-left: 4px solid var(--color-accent);
     margin-bottom: 2rem;
     font-style: italic;
-  }
-  /** make this border like gemini colors moving around as gradient  */
-  #summary.can-summarize{
-    margin-top: 2rem;
-    width: 60ch;  
-    border-left: 4px solid var(--color-accent);
-    animation: gemini-border 1s infinite ease-in cubic-bezier(0.1, -0.6, 0.2, 0);
   }
   #summary.can-summarize::before{
     content: '🤖 This summary was generated with AI';
@@ -213,14 +234,14 @@ const shareButton = document.getElementById('share');
     margin-bottom: 0.5rem;
   }
   .can-summarize {
-  position: relative;
-  padding: 2rem;
-  border-radius: 1rem;
-  z-index: 0;
-  overflow: hidden;
-}
-.can-summarize:after{
-  background: var(--color-dark);
+    position: relative;
+    padding: 2rem;
+    border-radius: 1rem;
+    z-index: 0;
+    overflow: hidden;
+  }
+  .can-summarize:after{
+    background: var(--color-dark);
     content: '';
     position: absolute;
     inset: 0;
@@ -229,35 +250,35 @@ const shareButton = document.getElementById('share');
     z-index: -1;
     margin: 5px;
     border-radius: 15px;
-}
-.can-summarize::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 4px;
-  background: conic-gradient(
+  }
+  .can-summarize::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 4px;
+    background: conic-gradient(
     from 0deg,
     #ff00cc,
     #3333ff,
     #00ffcc,
     #ffcc00,
     #ff00cc
-  );
-  z-index: -1;
-  height: 100%;
-  width: 250%;
-  animation: spin 15s linear infinite;
-}
-
-.can-summarize > * {
-  position: relative;
-  z-index: 1;
-}
-
-@keyframes spin {
-  to {
-    transform: rotate(360deg);
+    );
+    z-index: -1;
+    height: 100%;
+    width: 250%;
+    animation: spin 15s linear infinite;
   }
-}
+  
+  .can-summarize > * {
+    position: relative;
+    z-index: 1;
+  }
+  
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
 </style>

--- a/src/pages/notebook/[note].astro
+++ b/src/pages/notebook/[note].astro
@@ -43,7 +43,10 @@ pathToTranslateNote={pathToTranslateNote}
   {cover && coverAlt && <Picture src={cover} alt={coverAlt} width={500}/>}
   <figcaption>{coverAlt}</figcaption>
 </figure>
-<div id="summary"></div>
+<div id="summary">
+  <button id="generate-summary" class="button button-primary">Generate Summary</button>
+
+</div>
 <div id="content">
   <h1>{title}</h1>
   <Content/>
@@ -57,17 +60,15 @@ pathToTranslateNote={pathToTranslateNote}
 <script type="module">
   import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
   if ('Summarizer' in self) {
-    
     const summaryElement = document.getElementById('summary');
     summaryElement.classList.add('can-summarize');
-    
     async function summarizeContent(){
       const options = {
-        sharedContext: 'This is a FrontEnd developers article',
+        sharedContext: 'This is a FrontEnd developers article use same language as text for the summary',
         type: 'teaser',
         format: 'markdown',
         length: 'long',
-        language: 'en',
+        language: 'es',
         monitor(m) {
           m.addEventListener('downloadprogress', (e) => {
             console.log(`Downloaded ${e.loaded * 100}%`);
@@ -75,18 +76,16 @@ pathToTranslateNote={pathToTranslateNote}
         }
       };
       const availability = await Summarizer.availability();
-      console.log('Summarizer availability:', availability);
       if (availability === 'unavailable') {
         // The Summarizer API isn't usable.
         return;
       }
-      document.getElementById('summary').addEventListener('click', async () => {
-      // Check for user activation before creating the summarizer
+      const summaryButton = document.getElementById('generate-summary');
+      summaryButton.addEventListener('click', async () => {
         const summarizer = await Summarizer.create(options);
-        console.log({summarizer})
         const text= document.getElementById('content').innerText;
         summaryElement.innerText = 'Generating summary...';
-        const summary = await summarizer.summarizeStreaming(text,{ language: 'en' });
+        const summary = await summarizer.summarizeStreaming(text, { language: 'es' });
         summaryElement.innerText = '';
         for await (const chunk of summary.values()) {
           summaryElement.innerText += chunk;
@@ -202,18 +201,25 @@ pathToTranslateNote={pathToTranslateNote}
     font-size: clamp(.8rem, 2vw, 1.125rem);
     line-height: 1.6;
   }
-  #summary{
-    max-width: 60ch;
+  #summary h1 {
+    font-size: clamp(1.2rem, 3vw, 1.8rem);
+  }
+  #summary h2 {
+    font-size: clamp(1rem, 2.8vw, 1.5rem);
+  }
+  #summary h3 {
+    font-size: clamp(0.875rem, 2.4vw, 1.25rem);
+  }
+
+  /** make this border like gemini colors moving around as gradient  */
+  #summary.can-summarize{
     width: 90%;
     background-color: light-dark(var(--color-summary-light), var(--color-summary-dark));
     border-left: 4px solid var(--color-accent);
     margin-bottom: 2rem;
     font-style: italic;
-  }
-  /** make this border like gemini colors moving around as gradient  */
-  #summary.can-summarize{
     margin-top: 2rem;
-    width: 60ch;  
+    max-width: 60ch;  
     border-left: 4px solid var(--color-accent);
     animation: gemini-border 1s infinite ease-in cubic-bezier(0.1, -0.6, 0.2, 0);
   }


### PR DESCRIPTION
This pull request enhances the summary generation feature for notebook pages in both Spanish (`src/pages/es/cuaderno/[note].astro`) and English (`src/pages/notebook/[note].astro`). The main improvements include adding a user-triggered summary button, refining the summary generation logic to use the correct language, and updating the summary section's styling for better readability and visual consistency.

**Summary generation feature improvements:**

* Added a "Generate Summary" button to the summary section, allowing users to trigger AI-generated summaries on demand. ([src/pages/es/cuaderno/[note].astroL47-R49](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L47-R49), [src/pages/notebook/[note].astroL46-R49](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8L46-R49))
* Updated the summary generation logic to ensure the summary uses the same language as the article text (Spanish for both pages), and improved the options passed to the Summarizer API for more accurate results. ([src/pages/es/cuaderno/[note].astroL63-R88](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L63-R88), [src/pages/notebook/[note].astroL60-R88](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8L60-R88))
* Changed the summary generation to only activate when the Summarizer API is available, and moved the summary generation to be triggered by the new button instead of clicking the summary area. ([src/pages/es/cuaderno/[note].astroL63-R88](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L63-R88), [src/pages/notebook/[note].astroL60-R88](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8L60-R88))
* Improved handling of summary output by rendering the generated markdown and providing user feedback during generation. ([src/pages/es/cuaderno/[note].astroL89-R97](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L89-R97))

**Styling and visual enhancements:**

* Refined the CSS for the summary section, including responsive font sizes for headings and paragraphs, and improved the appearance of the summary box when active. ([src/pages/es/cuaderno/[note].astroL190-R227](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L190-R227), [src/pages/notebook/[note].astroL205-R222](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8L205-R222))