### PR TITLE
Fix/ia interacion

### DIFF
--- a/src/pages/es/cuaderno/[note].astro
+++ b/src/pages/es/cuaderno/[note].astro
@@ -64,11 +64,12 @@ pathToTranslateNote={pathToTranslateNote}
     summaryElement.classList.add('can-summarize');
     async function summarizeContent(){
       const options = {
-        sharedContext: 'This is a FrontEnd developers article use same language as text for the summary',
+        sharedContext: 'This is a FrontEnd developers article use same language as text for the summary the author is Giorgiosaud and is less formal but technical',
         type: 'teaser',
         format: 'markdown',
-        length: 'long',
-        language: 'es',
+        length: "medium",
+        expectedInputLanguages: ["es-ES"],
+        outputLanguage: 'es-ES',
         monitor(m) {
           m.addEventListener('downloadprogress', (e) => {
             console.log(`Downloaded ${e.loaded * 100}%`);

--- a/src/pages/es/cuaderno/[note].astro
+++ b/src/pages/es/cuaderno/[note].astro
@@ -77,15 +77,12 @@ pathToTranslateNote={pathToTranslateNote}
         }
       };
       const availability = await Summarizer.availability();
-      if (availability === 'unavailable') {
-        // The Summarizer API isn't usable.
-        return;
-      }
-      const summaryButton = document.getElementById('generate-summary');
-      summaryButton.addEventListener('click', async () => {
+      console.log({availability})
+
+      async function summarizeExec(){
+        summaryElement.innerText = 'Generando resumen...';
         const summarizer = await Summarizer.create(options);
         const text= document.getElementById('content').innerText;
-        summaryElement.innerText = 'Generating summary...';
         const summary = await summarizer.summarizeStreaming(text, { language: 'es' });
         summaryElement.innerText = '';
         for await (const chunk of summary.values()) {
@@ -95,6 +92,17 @@ pathToTranslateNote={pathToTranslateNote}
         summaryElement.innerHTML =
         marked.parse(summaryElement.innerText);
         console.log('Summary generation completed.');
+      }
+      if(availability==='available'){
+        summarizeExec();
+      }
+      if (availability === 'unavailable') {
+        // The Summarizer API isn't usable.
+        return;
+      }
+      const summaryButton = document.getElementById('generate-summary');
+      summaryButton.addEventListener('click', async () => {
+        summarizeExec();
       });
       
     };

--- a/src/pages/notebook/[note].astro
+++ b/src/pages/notebook/[note].astro
@@ -78,12 +78,12 @@ pathToTranslateNote={pathToTranslateNote}
         }
       };
       const availability = await Summarizer.availability();
+      console.log({availability})
       if (availability === 'unavailable') {
         // The Summarizer API isn't usable.
         return;
       }
-      const summaryButton = document.getElementById('generate-summary');
-      summaryButton.addEventListener('click', async () => {
+      async function summarizeExec(){
         const summarizer = await Summarizer.create(options);
         const text= document.getElementById('content').innerText;
         summaryElement.innerText = 'Generating summary...';
@@ -96,6 +96,13 @@ pathToTranslateNote={pathToTranslateNote}
         summaryElement.innerHTML =
         marked.parse(summaryElement.innerText);
         console.log('Summary generation completed.');
+      }
+      if(availability==='available'){
+        summarizeExec();
+      }
+      const summaryButton = document.getElementById('generate-summary');
+      summaryButton.addEventListener('click', async () => {
+        summarizeExec();
       });
     };
     summarizeContent();

--- a/src/pages/notebook/[note].astro
+++ b/src/pages/notebook/[note].astro
@@ -60,15 +60,17 @@ pathToTranslateNote={pathToTranslateNote}
 <script type="module">
   import { marked } from "https://cdn.jsdelivr.net/npm/marked/lib/marked.esm.js";
   if ('Summarizer' in self) {
+    console.log('Summarizer is available');
     const summaryElement = document.getElementById('summary');
     summaryElement.classList.add('can-summarize');
     async function summarizeContent(){
       const options = {
-        sharedContext: 'This is a FrontEnd developers article use same language as text for the summary',
+        sharedContext: 'This is a FrontEnd developers article use same language as text for the summary el autor siempre es Giorgiosaud lenguaje tecnico pero cercano al lector',
         type: 'teaser',
         format: 'markdown',
-        length: 'long',
-        language: 'es',
+        length: 'medium',
+        expectedInputLanguages: ["en-US"],
+        outputLanguage: 'en-US',
         monitor(m) {
           m.addEventListener('downloadprogress', (e) => {
             console.log(`Downloaded ${e.loaded * 100}%`);
@@ -85,7 +87,7 @@ pathToTranslateNote={pathToTranslateNote}
         const summarizer = await Summarizer.create(options);
         const text= document.getElementById('content').innerText;
         summaryElement.innerText = 'Generating summary...';
-        const summary = await summarizer.summarizeStreaming(text, { language: 'es' });
+        const summary = await summarizer.summarizeStreaming(text, { language: 'en' });
         summaryElement.innerText = '';
         for await (const chunk of summary.values()) {
           summaryElement.innerText += chunk;
@@ -95,10 +97,12 @@ pathToTranslateNote={pathToTranslateNote}
         marked.parse(summaryElement.innerText);
         console.log('Summary generation completed.');
       });
-      
     };
     summarizeContent();
+
   };
+      console.log('clicking generate summary button',navigator.userActivation.isActive);
+
 </script>
 <script define:vars={{selfHealing}}>
   


### PR DESCRIPTION
This pull request refactors the summary generation logic in both the Spanish (`src/pages/es/cuaderno/[note].astro`) and English (`src/pages/notebook/[note].astro`) notebook pages. The main focus is on improving the user experience by adjusting the summary options, making the summary process more responsive, and ensuring the summary generation is tailored to the author's style and language. The changes also streamline the code by restructuring how summary generation is triggered.

**Summary generation logic and user experience improvements:**

* Updated the `sharedContext` option to specify that the author is Giorgiosaud and to use a less formal, technical, and reader-friendly tone for both Spanish and English summaries. ([src/pages/es/cuaderno/[note].astroL67-L87](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L67-L87), [src/pages/notebook/[note].astroR63-R90](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8R63-R90))
* Changed summary options: set `length` to "medium", replaced `language` with `expectedInputLanguages` and `outputLanguage` for more precise language handling in both pages. ([src/pages/es/cuaderno/[note].astroL67-L87](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L67-L87), [src/pages/notebook/[note].astroR63-R90](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8R63-R90))
* Refactored summary execution: moved summary generation logic into a reusable `summarizeExec` function and ensured it runs automatically if the summarizer is available, as well as on button click. ([src/pages/es/cuaderno/[note].astroR95-R105](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739R95-R105), [src/pages/notebook/[note].astroR99-R112](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8R99-R112))
* Improved user feedback: summary element now displays "Generando resumen..." or "Generating summary..." while the summary is being created. ([src/pages/es/cuaderno/[note].astroL67-L87](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739L67-L87), [src/pages/notebook/[note].astroR63-R90](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8R63-R90))
* Added logging for summarizer availability and button activation to aid debugging and monitoring. ([src/pages/es/cuaderno/[note].astroR95-R105](diffhunk://#diff-e5de25dc19502d62aeb6376eec96157c0aa54c57c44e89dcd72143bcb3b07739R95-R105), [src/pages/notebook/[note].astroR63-R90](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8R63-R90), [src/pages/notebook/[note].astroR99-R112](diffhunk://#diff-eb99b6d6244c545a3627c57e2271d28036dd5d20a1a3dc53084075a05e2172d8R99-R112))