### PR TITLE
perf(notebook): ssr initial notes list to eliminate loading flash

### DIFF
--- a/src/global/scripts/notebook-search.ts
+++ b/src/global/scripts/notebook-search.ts
@@ -310,5 +310,14 @@ export function initNotebookSearch(options: {
   // Initialize from URL params on page load
   inputEl.value = currentParams.q
   updateChips(currentParams.collection)
-  fetchResults(currentParams)
+  // Skip initial fetch if the server already rendered the first page
+  const ssrRendered = resultsEl.dataset.ssr === 'true'
+  if (
+    !ssrRendered ||
+    currentParams.q ||
+    currentParams.collection ||
+    currentParams.page > 1
+  ) {
+    fetchResults(currentParams)
+  }
 }

--- a/src/pages/es/cuaderno/index.astro
+++ b/src/pages/es/cuaderno/index.astro
@@ -1,11 +1,54 @@
 ---
 import { getCollection } from 'astro:content'
+import { getPublishedNotes } from '@helpers/collections'
 import Base from '@templates/Base.astro'
+import { runSearch } from '../../../helpers/search'
 
 const lang = 'es'
 
 const collections = await getCollection('colecciones')
 const chipId = (id: string) => id.replace(/^\d{4}-\d{2}-\d{2}-/, '')
+
+const url = Astro.url
+const hasQuery = url.searchParams.has('q') || url.searchParams.has('collection')
+
+let initialHtml = ''
+if (!hasQuery) {
+  const allNotes = await getPublishedNotes('es')
+  const result = runSearch(allNotes, {
+    lang: 'es',
+    page: 1,
+  })
+  initialHtml = result.results
+    .map(note => {
+      const title = note.title
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+      const description = (note.description ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+      const coverAlt = (note.coverAlt ?? title).replace(/"/g, '&quot;')
+      const collection = note.collections[0] ?? ''
+      const imgVtn = `note-img-${note.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+      const titleVtn = `note-title-${note.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+      const imgHtml = note.coverSrc
+        ? `<div class="card-thumb" style="view-transition-name:${imgVtn}"><img src="${note.coverSrc.replace(/"/g, '&quot;')}" alt="${coverAlt}" loading="lazy" /></div>`
+        : ''
+      return `<li class="note-card-item">
+      <article aria-label="${title}" data-link="${note.href}" data-collection="${collection}">
+        <div class="wrapper">
+          ${imgHtml}
+          <div class="title" style="view-transition-name:${titleVtn}" title="${title}"><h2>${title}</h2></div>
+          <div class="description" title="${description}"><p>${description}</p></div>
+        </div>
+        <a href="${note.href}" class="card-link" aria-label="${coverAlt}"></a>
+      </article>
+    </li>`
+    })
+    .join('')
+}
 ---
 
 <Base title="Cuaderno" pathToTranslate="notebook">
@@ -41,8 +84,11 @@ const chipId = (id: string) => id.replace(/^\d{4}-\d{2}-\d{2}-/, '')
       ))}
     </div>
 
-    <ul id="search-results" class="notes-grid" aria-live="polite">
-      <li class="loading"><p>Cargando…</p></li>
+    <ul id="search-results" class="notes-grid" aria-live="polite" data-ssr={!hasQuery ? 'true' : 'false'}>
+      {hasQuery
+        ? <li class="loading"><p>Cargando…</p></li>
+        : <Fragment set:html={initialHtml} />
+      }
     </ul>
 
     <div id="pagination" class="pagination" aria-label="Paginación"></div>

--- a/src/pages/notebook/index.astro
+++ b/src/pages/notebook/index.astro
@@ -1,13 +1,56 @@
 ---
 import { getCollection } from 'astro:content'
+import { getPublishedNotes } from '@helpers/collections'
 import { useTranslations } from '@i18n/utils'
 import Base from '@templates/Base.astro'
+import { runSearch } from '../../helpers/search'
 
 const lang = 'en'
 const t = useTranslations(lang)
 
 const collections = await getCollection('collections')
 const chipId = (id: string) => id.replace(/^\d{4}-\d{2}-\d{2}-/, '')
+
+const url = Astro.url
+const hasQuery = url.searchParams.has('q') || url.searchParams.has('collection')
+
+let initialHtml = ''
+if (!hasQuery) {
+  const allNotes = await getPublishedNotes('en')
+  const result = runSearch(allNotes, {
+    lang: 'en',
+    page: 1,
+  })
+  initialHtml = result.results
+    .map(note => {
+      const title = note.title
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+      const description = (note.description ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+      const coverAlt = (note.coverAlt ?? title).replace(/"/g, '&quot;')
+      const collection = note.collections[0] ?? ''
+      const imgVtn = `note-img-${note.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+      const titleVtn = `note-title-${note.id.replace(/[^a-zA-Z0-9_-]/g, '-')}`
+      const imgHtml = note.coverSrc
+        ? `<div class="card-thumb" style="view-transition-name:${imgVtn}"><img src="${note.coverSrc.replace(/"/g, '&quot;')}" alt="${coverAlt}" loading="lazy" /></div>`
+        : ''
+      return `<li class="note-card-item">
+      <article aria-label="${title}" data-link="${note.href}" data-collection="${collection}">
+        <div class="wrapper">
+          ${imgHtml}
+          <div class="title" style="view-transition-name:${titleVtn}" title="${title}"><h2>${title}</h2></div>
+          <div class="description" title="${description}"><p>${description}</p></div>
+        </div>
+        <a href="${note.href}" class="card-link" aria-label="${coverAlt}"></a>
+      </article>
+    </li>`
+    })
+    .join('')
+}
 ---
 
 <Base title="Notebook" pathToTranslate="notebook">
@@ -43,8 +86,11 @@ const chipId = (id: string) => id.replace(/^\d{4}-\d{2}-\d{2}-/, '')
       ))}
     </div>
 
-    <ul id="search-results" class="notes-grid" aria-live="polite">
-      <li class="loading"><p>Loading…</p></li>
+    <ul id="search-results" class="notes-grid" aria-live="polite" data-ssr={!hasQuery ? 'true' : 'false'}>
+      {hasQuery
+        ? <li class="loading"><p>Loading…</p></li>
+        : <Fragment set:html={initialHtml} />
+      }
     </ul>
 
     <div id="pagination" class="pagination" aria-label="Pagination"></div>


### PR DESCRIPTION
## Summary
- Renderiza la primera página de notas en el servidor (SSR) para eliminar el flash de "Loading…"
- El cliente solo hace fetch al API cuando hay búsqueda activa (query o filtro en URL)
- Aprovecha el caché de Vercel — sin interacción, cero requests al API

## Changes

| File | Change |
|------|--------|
| `src/pages/notebook/index.astro` | SSR initial notes, skip client fetch when no query |
| `src/pages/es/cuaderno/index.astro` | Mismo tratamiento para versión ES |
| `src/global/scripts/notebook-search.ts` | Detecta `data-ssr` para saltar fetch inicial |