### PR TITLE
fix(cookie-consent): gdpr compliance, dark mode colors, compact layout

### DIFF
--- a/src/content/pages/en/privacy-policy.md
+++ b/src/content/pages/en/privacy-policy.md
@@ -1,0 +1,71 @@
+---
+title: "Privacy Policy"
+description: "How giorgiosaud.io collects, uses, and protects your personal data in compliance with GDPR."
+pathToTranslate: privacy
+---
+
+# 🔒 Privacy Policy
+
+**Last updated: April 2026**
+
+This policy explains how **giorgiosaud.io** (operated by Jorge Luis Saud Rosal) collects and handles your personal data.
+
+---
+
+## What Data We Collect
+
+### Cookies & Tracking
+We only activate analytics and marketing cookies **after you give explicit consent**. You can change your preferences at any time using the cookie settings button at the bottom of the page.
+
+| Category | Purpose | Optional? |
+|----------|---------|-----------|
+| Necessary | Site functionality (session, security) | No |
+| Analytics | Usage stats via Google Analytics (GTM) | Yes |
+| Marketing | Personalized advertising | Yes |
+
+### Contact Form
+When you use the contact form, we collect your name, email address, and message to respond to your inquiry. This data is processed via [Resend](https://resend.com) and is not shared with third parties.
+
+### Consent Records
+When you make a cookie choice, we store an anonymized record (hashed IP, session ID, choice, timestamp) for GDPR audit purposes. Your IP address is never stored in plain text.
+
+---
+
+## Your Rights (GDPR)
+
+Under the GDPR you have the right to:
+- **Access** — request a copy of your personal data
+- **Rectification** — correct inaccurate data
+- **Erasure** — request deletion of your data
+- **Withdraw consent** — at any time, without affecting prior processing
+- **Lodge a complaint** — with your national data protection authority
+
+To exercise any right, contact: **jorgelsaud@gmail.com**
+
+---
+
+## Data Retention
+
+- Consent records are kept for **3 years** for audit compliance.
+- Contact form submissions are kept until the inquiry is resolved.
+
+---
+
+## Third-Party Services
+
+- **Google Tag Manager / Analytics** — activated only with analytics consent
+- **Resend** — contact form email delivery
+- **Vercel** — hosting; may log IP addresses for security (see [Vercel Privacy Policy](https://vercel.com/legal/privacy-policy))
+- **Cloudflare Turnstile** — bot protection on forms
+
+---
+
+## Changes to This Policy
+
+We will update this page when our practices change and bump the cookie consent version so you are re-asked for consent.
+
+---
+
+## Contact
+
+Jorge Luis Saud Rosal · [jorgelsaud@gmail.com](mailto:jorgelsaud@gmail.com)

--- a/src/content/pages/es/politica-de-privacidad.md
+++ b/src/content/pages/es/politica-de-privacidad.md
@@ -1,0 +1,71 @@
+---
+title: "Política de Privacidad"
+description: "Cómo giorgiosaud.io recopila, usa y protege tus datos personales conforme al RGPD."
+pathToTranslate: privacy
+---
+
+# 🔒 Política de Privacidad
+
+**Última actualización: abril de 2026**
+
+Esta política explica cómo **giorgiosaud.io** (operado por Jorge Luis Saud Rosal) recopila y gestiona tus datos personales.
+
+---
+
+## Qué datos recopilamos
+
+### Cookies y seguimiento
+Solo activamos cookies de analítica y marketing **después de que des tu consentimiento explícito**. Puedes cambiar tus preferencias en cualquier momento usando el botón de configuración de cookies al pie de la página.
+
+| Categoría | Propósito | ¿Opcional? |
+|-----------|-----------|------------|
+| Necesarias | Funcionalidad del sitio (sesión, seguridad) | No |
+| Analítica | Estadísticas de uso mediante Google Analytics (GTM) | Sí |
+| Marketing | Publicidad personalizada | Sí |
+
+### Formulario de contacto
+Cuando usas el formulario de contacto, recopilamos tu nombre, email y mensaje para responder a tu consulta. Estos datos se procesan mediante [Resend](https://resend.com) y no se comparten con terceros.
+
+### Registros de consentimiento
+Cuando eliges tus preferencias de cookies, almacenamos un registro anonimizado (IP hasheada, ID de sesión, elección, marca de tiempo) para auditoría RGPD. Tu dirección IP nunca se almacena en texto plano.
+
+---
+
+## Tus derechos (RGPD)
+
+Bajo el RGPD tienes derecho a:
+- **Acceso** — solicitar una copia de tus datos personales
+- **Rectificación** — corregir datos inexactos
+- **Supresión** — solicitar la eliminación de tus datos
+- **Retirar el consentimiento** — en cualquier momento, sin afectar el procesamiento previo
+- **Presentar una reclamación** — ante tu autoridad nacional de protección de datos
+
+Para ejercer cualquier derecho, contacta: **jorgelsaud@gmail.com**
+
+---
+
+## Retención de datos
+
+- Los registros de consentimiento se conservan **3 años** para cumplimiento de auditoría.
+- Los envíos del formulario de contacto se conservan hasta resolver la consulta.
+
+---
+
+## Servicios de terceros
+
+- **Google Tag Manager / Analytics** — activado solo con consentimiento de analítica
+- **Resend** — envío de emails del formulario de contacto
+- **Vercel** — alojamiento; puede registrar IPs por seguridad (ver [Política de Privacidad de Vercel](https://vercel.com/legal/privacy-policy))
+- **Cloudflare Turnstile** — protección antibot en formularios
+
+---
+
+## Cambios en esta política
+
+Actualizaremos esta página cuando cambien nuestras prácticas y aumentaremos la versión del consentimiento de cookies para que se te solicite de nuevo.
+
+---
+
+## Contacto
+
+Jorge Luis Saud Rosal · [jorgelsaud@gmail.com](mailto:jorgelsaud@gmail.com)

--- a/src/global/components/CookieConsent.svelte
+++ b/src/global/components/CookieConsent.svelte
@@ -4,6 +4,7 @@ import { onMount } from 'svelte'
 const CONSENT_KEY = 'cookie_consent'
 const CONSENT_SESSION_KEY = 'consent_session_id'
 const CONSENT_VERSION = '1' // Bump this to re-ask consent
+const CONSENT_EXPIRY_MS = 365 * 24 * 60 * 60 * 1000 // 12 months
 
 type ConsentState = {
   necessary: boolean
@@ -65,8 +66,8 @@ onMount(() => {
   if (stored) {
     try {
       const parsed = JSON.parse(stored) as ConsentState
-      // Re-ask if version changed
-      if (parsed.version !== CONSENT_VERSION) {
+      const expired = Date.now() - (parsed.timestamp || 0) > CONSENT_EXPIRY_MS
+      if (parsed.version !== CONSENT_VERSION || expired) {
         showBanner = true
       } else {
         consent = parsed
@@ -77,6 +78,12 @@ onMount(() => {
     }
   } else {
     showBanner = true
+  }
+
+  // Expose re-open function globally so footer/other UI can trigger it
+  window.__openCookieSettings = () => {
+    showBanner = true
+    showSettings = false
   }
 })
 
@@ -142,16 +149,23 @@ declare global {
   interface Window {
     dataLayer: unknown[]
     gtag: (...args: unknown[]) => void
+    __openCookieSettings: () => void
   }
 }
 </script>
+
+{#if !showBanner}
+  <button type="button" class="manage-btn" onclick={() => { showBanner = true; showSettings = false }}>
+    🍪 Cookies
+  </button>
+{/if}
 
 {#if showBanner}
   <div class="cookie-banner" role="dialog" aria-label="Cookie consent">
     {#if !showSettings}
       <div class="banner-content">
         <p>
-          We use cookies to enhance your experience. By continuing, you agree to our use of cookies.
+          We use cookies to enhance your experience. Read our <a href="/privacy-policy" class="policy-link">Privacy Policy</a> to learn more.
         </p>
         <div class="banner-actions">
           <button type="button" class="btn-link" onclick={() => showSettings = true}>
@@ -208,52 +222,79 @@ declare global {
 
 <style>
   .cookie-banner {
+    --_font-size: clamp(0.6875rem, 1.5vw, 0.75rem);
     position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: var(--color-surface, #fff);
-    border-top: 1px solid var(--color-border, #ddd);
-    padding: 1rem;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    width: min(360px, calc(100vw - 2rem));
+    background: #1e293b;
+    color: #e2e8f0;
+    border: 1px solid #334155;
+    border-radius: 12px;
+    padding: 1rem 1.25rem;
+    font-size: var(--_font-size);
     z-index: 9998;
-    box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  }
+
+  :global(.light) .cookie-banner,
+  :global([data-theme="light"]) .cookie-banner {
+    background: #ffffff;
+    color: #1e293b;
+    border-color: #e2e8f0;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
   }
 
   .banner-content, .settings-content {
-    max-width: 900px;
-    margin: 0 auto;
-  }
-
-  .banner-content {
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
+    flex-direction: column;
+    gap: 0.75rem;
   }
 
   .banner-content p {
     margin: 0;
-    flex: 1;
-    min-width: 200px;
+    font-size: inherit;
+    line-height: 1.5;
+    color: #94a3b8;
+  }
+
+  .policy-link {
+    font-size: inherit;
+  }
+
+  :global(.light) .banner-content p,
+  :global([data-theme="light"]) .banner-content p {
+    color: #64748b;
   }
 
   .banner-actions, .settings-actions {
     display: flex;
     gap: 0.5rem;
     flex-wrap: wrap;
+    justify-content: flex-end;
   }
 
   .settings-content h3 {
-    margin: 0 0 1rem;
-    font-size: 1.125rem;
+    margin: 0;
+    font-size: calc(var(--_font-size) * 1.2);
+    color: #f1f5f9;
+  }
+
+  :global(.light) .settings-content h3,
+  :global([data-theme="light"]) .settings-content h3 {
+    color: #0f172a;
   }
 
   .cookie-option {
-    margin-bottom: 1rem;
-    padding: 0.75rem;
-    background: var(--color-background, #f9f9f9);
-    border-radius: 4px;
+    margin-bottom: 0.5rem;
+    padding: 0.625rem;
+    background: #0f172a;
+    border-radius: 6px;
+  }
+
+  :global(.light) .cookie-option,
+  :global([data-theme="light"]) .cookie-option {
+    background: #f1f5f9;
   }
 
   .cookie-option label {
@@ -261,61 +302,102 @@ declare global {
     align-items: center;
     gap: 0.5rem;
     cursor: pointer;
+    color: #e2e8f0;
+  }
+
+  :global(.light) .cookie-option label,
+  :global([data-theme="light"]) .cookie-option label {
+    color: #1e293b;
   }
 
   .option-title {
     font-weight: 500;
+    font-size: 0.875rem;
   }
 
   .option-desc {
     margin: 0.25rem 0 0 1.5rem;
-    font-size: 0.875rem;
-    color: var(--color-muted, #666);
+    font-size: inherit;
+    color: #64748b;
   }
 
   .btn-primary {
-    padding: 0.5rem 1rem;
+    padding: 0.3rem 0.75rem;
     background: var(--color-main);
     color: white;
     border: none;
-    border-radius: 4px;
+    border-radius: 6px;
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: inherit;
+    font-weight: 500;
   }
 
   .btn-secondary {
-    padding: 0.5rem 1rem;
-    background: var(--color-surface, #e5e5e5);
-    color: var(--color-text, #333);
+    padding: 0.3rem 0.75rem;
+    background: #334155;
+    color: #e2e8f0;
     border: none;
-    border-radius: 4px;
+    border-radius: 6px;
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: inherit;
+  }
+
+  :global(.light) .btn-secondary,
+  :global([data-theme="light"]) .btn-secondary {
+    background: #e2e8f0;
+    color: #1e293b;
   }
 
   .btn-link {
-    padding: 0.5rem 1rem;
+    padding: 0.3rem 0.375rem;
     background: none;
     border: none;
-    color: var(--color-main);
+    color: #94a3b8;
     cursor: pointer;
-    font-size: 0.875rem;
+    font-size: inherit;
     text-decoration: underline;
   }
 
-  .btn-primary:hover, .btn-secondary:hover {
-    opacity: 0.9;
+  :global(.light) .btn-link,
+  :global([data-theme="light"]) .btn-link {
+    color: #64748b;
   }
 
-  @media (max-width: 600px) {
-    .banner-content {
-      flex-direction: column;
-      text-align: center;
-    }
+  .btn-primary:hover { opacity: 0.9; }
+  .btn-secondary:hover { opacity: 0.85; }
 
-    .banner-actions {
-      justify-content: center;
-      width: 100%;
-    }
+  .policy-link {
+    color: #7dd3fc;
+    text-decoration: underline;
+  }
+
+  :global(.light) .policy-link,
+  :global([data-theme="light"]) .policy-link {
+    color: #0369a1;
+  }
+
+  .manage-btn {
+    position: fixed;
+    bottom: 1rem;
+    right: 1rem;
+    background: #1e293b;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    border-radius: 8px;
+    padding: 0.375rem 0.625rem;
+    font-size: 0.6875rem;
+    cursor: pointer;
+    z-index: 9997;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+  }
+
+  .manage-btn:hover { opacity: 1; }
+
+  :global(.light) .manage-btn,
+  :global([data-theme="light"]) .manage-btn {
+    background: #f8fafc;
+    color: #64748b;
+    border-color: #e2e8f0;
   }
 </style>

--- a/src/global/i18n/routes.ts
+++ b/src/global/i18n/routes.ts
@@ -35,4 +35,8 @@ export const routes = {
     es: 'panel',
     en: 'dashboard',
   },
+  privacy: {
+    es: 'politica-de-privacidad',
+    en: 'privacy-policy',
+  },
 } as const


### PR DESCRIPTION
## Summary

- Cookie consent banner redesigned as compact bottom-right card (not full-width) with correct dark/light mode colors
- GDPR compliance gaps addressed: privacy policy link, re-open mechanism, 12-month consent expiry
- Privacy Policy pages created in EN (`/privacy-policy`) and ES (`/politica-de-privacidad`)
- Font sizing unified via a single `--_font-size` CSS custom property using `clamp()`

## Related Issues

- Relates to #

## Type of Change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Refactor / Code quality
- [ ] Performance
- [ ] Build / CI
- [ ] Style (formatting, no logic change)
- [ ] Chore
- [ ] Other:

## Screenshots / Demos

- Preview URL: (Vercel preview will appear after CI)
- Before: full-width banner, missing GDPR elements, poor dark mode contrast
- After: compact card bottom-right, privacy link, manage-cookies button, 12-month expiry

## How to Test

1. Open site in dark mode — banner should appear as a small card at bottom-right
2. Accept/reject cookies — check DB for consent record
3. Dismiss banner — verify small "🍪 Cookies" button remains for re-opening
4. Visit `/privacy-policy` and `/es/politica-de-privacidad` — pages should render

## Checklist

Project hygiene
- [x] PR title is clear and descriptive
- [x] Small, focused changes; non-essential diffs avoided

Code quality
- [x] All tests pass locally (126/126)
- [x] No new console errors/warnings

Astro/Content specifics
- [x] i18n route added for privacy policy
- [x] Accessibility reviewed (dialog role, aria-label on banner)

Risk & rollout
- [x] No secrets or sensitive data committed
- [x] No breaking changes